### PR TITLE
Added // comment feature

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "configurations": [
+        {
+            "type": "cmake",
+            "request": "launch",
+            "name": "Debug portfile(s)",
+            "cmakeDebugType": "external",
+            "pipeName": "\\\\.\\pipe\\vcpkg_ext_portfile_dbg",
+            "preLaunchTask": "Debug vcpkg commands"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "stdexcept": "cpp"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ In order to use the `max` value for the `amt` argument, the line must end in `,`
 ```
 key=value1,value2,value3,value4,
 ```
+
+Sometimes, you might want to insert comments in your EBSL file, which can be done by writing `//` at the start of each line. Note that if a line starts with `//` the whole line will be seen as a comment, and comments are ignored by the EBSL interpreter. Example:
+```
+// this is a comment
+key=value
+```

--- a/src/aml.cpp
+++ b/src/aml.cpp
@@ -5,6 +5,17 @@
 #include "fa.hpp"
 using namespace std;
 
+bool isComment(string str) {
+    // Find the first non-space character
+    auto it = std::find_if(str.begin(), str.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    });
+
+    // Check if the string starts with "//" after ignoring leading spaces
+    return (it != str.end() && std::distance(it, str.end()) > 1 && *it == '/' && *(it + 1) == '/');
+}
+
+
 vector<string> gval_aml(string key, string file, size_t amount) {
     regex key_r("^" + key + "=");
     regex sp(" ");
@@ -17,6 +28,9 @@ vector<string> gval_aml(string key, string file, size_t amount) {
     while(getline(fileTP, ln)) {
         if (amount == 0) {
             amount = find_a(ln);
+        }
+        if (isComment(ln)) {
+            cout << "yes" << "\n";
         }
         if (regex_search(ln, key_r)) {
             string ret_vp_ = regex_replace(ln, key_r, "");

--- a/src/include/aml.hpp
+++ b/src/include/aml.hpp
@@ -3,4 +3,5 @@
 #ifndef AML_H
 #define AML_H
 std::vector<std::string> gval_aml(std::string key, std::string file, size_t amount);
+bool isComment(std::string str);
 #endif


### PR DESCRIPTION
I feel like EBSL should have a comment feature where programmers can write comments that are meant to be read by themselves and/or other programmers instead of the EBSL interpreter, which is why I added the comment feature. Comments would start a line with `//` and the rest of the line will be ignored as a comment.